### PR TITLE
Pin Uncrustify version to 0.67

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(NOT res EQUAL 0)
 else()
   # version of uncrustify before 0.65 user a different versionning scheme so the regex wont be matched
   string(REGEX REPLACE "^Uncrustify-(.*)_f$" "\\1" version_prefix_match "${out}")
-  if(version_prefix_match STREQUAL "" OR version_prefix_match VERSION_LESS 0.67)
+  if(version_prefix_match STREQUAL "" OR NOT version_prefix_match VERSION_EQUAL 0.67)
     set(need_local_build TRUE)
   endif()
 endif()


### PR DESCRIPTION
Do not use newer versions.

With this change we can be sure the same version of Uncrustify is being used on all platforms.

Resolves ros2/rosidl#340