### PR TITLE
vendor package QNX fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ macro(build_uncrustify)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    if(QNX)
+      # defined in toolchain file
+      set_qnx_external_project_options()
+    endif()
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     if(ANDROID)
       if(DEFINED ANDROID_ABI)
@@ -37,7 +41,12 @@ macro(build_uncrustify)
   endif()
 
   include(ExternalProject)
-  find_package(Patch REQUIRED)
+
+  if(QNX)
+    find_host_package(Patch REQUIRED)
+  else()
+    find_package(Patch REQUIRED)
+  endif()
 
   # Pinning to tip of master at the time of a desired bugfix
   set(uncrustify_version 45b836cff040594994d364ad6fd3f04adc890a26)


### PR DESCRIPTION
Fixes #8
Fixes #10 

When cross compiling for QNX a toolchain file is provided to COLCON in addition to other command line arguments that are related to the architecture being built. Using cmake's externalproject_add() function, the value of the variables set from command line, outside the toolchain file, have to be re-passed to the external project by setting them again and including them in the extra_cmake_args variable. The macro set_qnx_external_project_options() implements this functionality.

Also in the tool chain file CMAKE_FIND_ROOT_PATH is set to only find_package() in the specific search paths provided for the intended architecture. Another macro find_host_package() had to be implemented in order to search for patch utility in the host file system. The macro find_host_package() is defined in the toolchain file.