### PR TITLE
Switch to applying patch with git apply.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ macro(build_uncrustify)
   endif()
 
   include(ExternalProject)
-  find_package(Patch REQUIRED)
 
   # Pinning to tip of master at the time of a desired bugfix
   set(uncrustify_version 45b836cff040594994d364ad6fd3f04adc890a26)
@@ -52,7 +51,7 @@ macro(build_uncrustify)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
This gets us closer to being able to build without Administrator
on Windows, since the "patch" command required Administrator.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>