### PR TITLE
Use Git to fetch upstream uncrustify source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,10 @@ macro(build_uncrustify)
 
   # Pinning to tip of master at the time of a desired bugfix
   set(uncrustify_version 45b836cff040594994d364ad6fd3f04adc890a26)
-  set(uncrustify_version_hash 7cc32ad800c8d639bdf145e2a113a66b)
   # Get uncrustify 0.68.1
   ExternalProject_Add(uncrustify-0.68.1
-    URL https://github.com/uncrustify/uncrustify/archive/${uncrustify_version}.tar.gz
-    URL_MD5 ${uncrustify_version_hash}
+    GIT_REPOSITORY https://github.com/uncrustify/uncrustify.git
+    GIT_TAG ${uncrustify_version}
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install


### PR DESCRIPTION
This is somewhat of a lateral move in general, but the patching solution implemented in #15 can fail under certain circumstances if the target directory is not a git repository.

Since the patching solution requires git anyway, and we're downloading what should be the exact same files, there should be no reason that this wouldn't work in largely the same way the current tarball-based solution does.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13355)](http://ci.ros2.org/job/ci_linux/13355/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8282)](http://ci.ros2.org/job/ci_linux-aarch64/8282/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11084)](http://ci.ros2.org/job/ci_osx/11084/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13406)](http://ci.ros2.org/job/ci_windows/13406/)