### PR TITLE
Use custom command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,13 @@ macro(build_uncrustify)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
       -Wno-dev
-    PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+  )
+  ExternalProject_Get_Property(uncrustify-0.68.1 STAMP_DIR)
+  ExternalProject_Get_Property(uncrustify-0.68.1 SOURCE_DIR)
+  add_custom_command(APPEND
+    OUTPUT ${STAMP_DIR}/uncrustify-0.68.1-download
+    COMMAND ${CMAKE_COMMAND} -E chdir "${SOURCE_DIR}" git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff"
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
This should work around an issue when trying to build the
package multiple times in some circumstances.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@cottsay I still can't reproduce the problem on Linux.  I was able to reproduce it on macOS, and tested that this fixes it there.  Can you give it a try?

This should fix #17 