### PR TITLE
Add git checkout before patching.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,14 @@ macro(build_uncrustify)
   ExternalProject_Add(uncrustify-0.68.1
     GIT_REPOSITORY https://github.com/uncrustify/uncrustify.git
     GIT_TAG ${uncrustify_version}
+    GIT_CONFIG advice.detachedHead=false
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git checkout -q . && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
This ensures that on subsequent runs, if the patch step is run
again it will successfully repatch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>