### PR TITLE
Use explicit INSTALL_COMMAND to suppress DESTDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ macro(build_uncrustify)
       -Wno-dev
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git checkout -q . && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+    # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/18165,
+    # which is exacerbated by https://gitlab.kitware.com/cmake/cmake/-/issues/16419.
+    # We're configuring the project to use CMAKE_INSTALL_PREFIX, so we never want
+    # DESTDIR to affect it.
     INSTALL_COMMAND
       ${CMAKE_COMMAND} -E env DESTDIR= ${CMAKE_COMMAND} --install .
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ macro(build_uncrustify)
       -Wno-dev
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git checkout -q . && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E env DESTDIR= ${CMAKE_COMMAND} --install .
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
The DESTDIR environment variable is used on UNIX systems during an invocation of 'make install' to specify an alternate directory prefix for installation paths. Since this isn't a cross-platform mechanism, the CMAKE_INSTALL_PREFIX CMake variable can also be used.

Unfortunately, if both of these are specified, they will both be applied. This isn't typically a problem, but can cause problems for the installation phase of ExternalProject_Add if the external project is built during an invocation of 'make install' with DESTDIR set.

Since the CMAKE_INSTALL_PREFIX method is employed by the call to ExternalProject_Add instead of DESTDIR, we should specifically suppress DESTDIR if it is set so that it doesn't interfere with the installation of the external project to the staging directory.

In this package, there is something subtle happening related to using `git` as an upstream source combined with a patching step that causes the external project to be re-built during the install phase. This is triggering the behavior described above. Each issue alone does not result in the misbehavior, but when both occur, the result is that the install phase of the external project installs the project to the wrong location - `$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}` - instead of just `${CMAKE_INSTALL_PREFIX}`, which corresponds to the staging directory.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13551)](http://ci.ros2.org/job/ci_linux/13551/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8445)](http://ci.ros2.org/job/ci_linux-aarch64/8445/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11274)](http://ci.ros2.org/job/ci_osx/11274/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13616)](http://ci.ros2.org/job/ci_windows/13616/)