### PR TITLE
Make git upstream act more like tar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,13 @@ macro(build_uncrustify)
   # Pinning to tip of master at the time of a desired bugfix
   set(uncrustify_version 45b836cff040594994d364ad6fd3f04adc890a26)
   # Get uncrustify 0.68.1
-  ExternalProject_Add(uncrustify-0.68.1
+  ExternalProject_Add(uncrustify-${uncrustify_version}
     GIT_REPOSITORY https://github.com/uncrustify/uncrustify.git
     GIT_TAG ${uncrustify_version}
     GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,6 @@ macro(build_uncrustify)
       -Wno-dev
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git checkout -q . && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
-    # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/18165,
-    # which is exacerbated by https://gitlab.kitware.com/cmake/cmake/-/issues/16419.
-    # We're configuring the project to use CMAKE_INSTALL_PREFIX, so we never want
-    # DESTDIR to affect it.
-    INSTALL_COMMAND
-      ${CMAKE_COMMAND} -E env DESTDIR= ${CMAKE_COMMAND} --install .
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ macro(build_uncrustify)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git checkout -q . && ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
This package is proving to be a perfect storm of the following two issues:
1. https://gitlab.kitware.com/cmake/cmake/-/issues/16419
2. https://gitlab.kitware.com/cmake/cmake/-/issues/18165

Issue (1) initially caused problems for this package because it has a patching step. We mitigated that in #20 by essentially reverting any changes prior to applying the patch. So (1) is still manifesting in these builds, we just made the patch step robust in the face of an unclean source tree.

Issue (2) actually affects all of our vendor packages, but we normally don't see it because everywhere we're using `DESTDIR` we're also using discrete build and install invocations. However, due to this package being affected by (1), the external package got rebuilt during the install phase and `DESTDIR` messed with the installation into the staging directory.

Rather than making our patch step more robust, this change suppresses the "update" step for the external package, which is why the patch step was getting re-run in the first place. Without this update step, the package will act much more like it did when we used a `URL` upstream instead of `GIT_REPOSITORY`.

The one caveat is that a change to `GIT_TAG` doesn't seem to invalidate the target like changing `URL` or `GIT_REPOSITORY` would. To mitigate that, I changed the entire target's name to include the ref, which is probably more accurate anyway.

This changes reverts #20 because it is no longer needed in this package any more than it might be needed in a `URL`-based package.

This change also reverts #21 because it was causing problems on Windows, and the package should no longer misbehave when faced with `DESTDIR` as long as discrete build and install phases are used properly.

Release:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13572)](http://ci.ros2.org/job/ci_linux/13572/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8463)](http://ci.ros2.org/job/ci_linux-aarch64/8463/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11293)](http://ci.ros2.org/job/ci_osx/11293/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13635)](http://ci.ros2.org/job/ci_windows/13635/)

Debug:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13573)](http://ci.ros2.org/job/ci_linux/13573/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8464)](http://ci.ros2.org/job/ci_linux-aarch64/8464/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11294)](http://ci.ros2.org/job/ci_osx/11294/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13636)](http://ci.ros2.org/job/ci_windows/13636/)