### PR TITLE
Update to uncrustify 0.72

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,12 @@ macro(build_uncrustify)
 
   # Get uncrustify 0.72.0
   ExternalProject_Add(uncrustify-0.72.0
-    URL https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
-    URL_MD5 9e89cd3457cb1b431eab5c7a161c02a2
+    GIT_REPOSITORY https://github.com/uncrustify/uncrustify.git
+    GIT_TAG uncrustify-0.72.0
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,10 @@ macro(build_uncrustify)
 
   include(ExternalProject)
 
-  # Pinning to tip of master at the time of a desired bugfix
-  set(uncrustify_version 45b836cff040594994d364ad6fd3f04adc890a26)
-  # Get uncrustify 0.68.1
-  ExternalProject_Add(uncrustify-${uncrustify_version}
-    GIT_REPOSITORY https://github.com/uncrustify/uncrustify.git
-    GIT_TAG ${uncrustify_version}
-    GIT_CONFIG advice.detachedHead=false
-    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
-    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
-    UPDATE_COMMAND ""
+  # Get uncrustify 0.72.0
+  ExternalProject_Add(uncrustify-0.72.0
+    URL https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
+    URL_MD5 9e89cd3457cb1b431eab5c7a161c02a2
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
@@ -83,9 +77,9 @@ set(need_local_build FALSE)
 if(NOT res EQUAL 0)
   set(need_local_build TRUE)
 else()
-  # version of uncrustify before 0.65 user a different versionning scheme so the regex wont be matched
+  # Before 0.65 uncrustify used a different versioning scheme so the regex won't match
   string(REGEX REPLACE "^Uncrustify-(.*)_f$" "\\1" version_prefix_match "${out}")
-  if(version_prefix_match STREQUAL "" OR version_prefix_match VERSION_LESS 0.68)
+  if(version_prefix_match STREQUAL "" OR version_prefix_match VERSION_LESS 0.72)
     set(need_local_build TRUE)
   endif()
 endif()

--- a/install-patch.diff
+++ b/install-patch.diff
@@ -1,17 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index db0a6bfb..26ccf1a5 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -440,33 +440,33 @@ include(CPack)
+--- a/CMakeLists.txt	2021-12-10 16:10:01.557816597 -0500
++++ b/CMakeLists.txt	2021-12-10 16:11:16.521464522 -0500
+@@ -500,32 +500,33 @@
  # Install
  #
  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 -  install(TARGETS uncrustify DESTINATION ".")
--  install(
--    FILES
--      "${PROJECT_SOURCE_DIR}/README.md"
--      "${PROJECT_SOURCE_DIR}/BUGS"
--      "${PROJECT_SOURCE_DIR}/ChangeLog"
+-  install(FILES ${uncrustify_docs}
 -    DESTINATION "."
 -  )
 -  install(FILES "${PROJECT_SOURCE_DIR}/documentation/htdocs/index.html"
@@ -22,11 +18,8 @@ index db0a6bfb..26ccf1a5 100644
 -    FILES_MATCHING PATTERN "*.cfg"
 -  )
 +  install(TARGETS uncrustify RUNTIME DESTINATION bin)
-+  # install(
-+  #   FILES
-+  #     "${PROJECT_SOURCE_DIR}/README.md"
-+  #     "${PROJECT_SOURCE_DIR}/BUGS"
-+  #     "${PROJECT_SOURCE_DIR}/ChangeLog"
++  # install(TARGETS uncrustify DESTINATION ".")
++  # install(FILES ${uncrustify_docs}
 +  #   DESTINATION "."
 +  # )
 +  # install(FILES "${PROJECT_SOURCE_DIR}/documentation/htdocs/index.html"
@@ -45,15 +38,21 @@ index db0a6bfb..26ccf1a5 100644
 -    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
 -  )
 -  install(DIRECTORY "${PROJECT_SOURCE_DIR}/etc/"
--    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/uncrustify"
+-    DESTINATION "${CMAKE_INSTALL_DOCDIR}/examples"
 -    FILES_MATCHING PATTERN "*.cfg"
+-  )
+-  install(FILES ${uncrustify_docs}
+-    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
 -  )
 +  # install(FILES "${CMAKE_CURRENT_BINARY_DIR}/uncrustify.1"
 +  #   DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
 +  # )
 +  # install(DIRECTORY "${PROJECT_SOURCE_DIR}/etc/"
-+  #   DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/uncrustify"
++  #   DESTINATION "${CMAKE_INSTALL_DOCDIR}/examples"
 +  #   FILES_MATCHING PATTERN "*.cfg"
++  # )
++  # install(FILES ${uncrustify_docs}
++  #   DESTINATION "${CMAKE_INSTALL_DOCDIR}"
 +  # )
  endif()
  


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This updates our vendored version of uncrustify to 0.72.  The most compelling reason to do this is to make it match the version that is going to ship with Ubuntu Jammy.  Along with this change, we are also going to need updates to a number of downstream repositories.  I'll link each of the changes we need to this pull request, and run CI on the whole lot here.  I'll pull it out of draft once I have CI happy.