### PR TITLE
Add statement for variable not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ else()
 endif()
 if(FORCE_BUILD_VENDOR_PKG OR need_local_build)
   build_uncrustify()
+else()
+  set(ignoreMe "${CMAKE_BUILD_TYPE}$")
 endif()
 
 # this ensures that the package has an environment hook setting the PATH


### PR DESCRIPTION
Checking if this would fix the current CMake warning on windows.
https://ci.ros2.org/view/nightly/job/nightly_win_deb/2212/msbuild/

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>