### PR TITLE
Quiet down build warning on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ macro(build_uncrustify)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
       -Wno-dev
+      --no-warn-unused-cli
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/install-patch.diff
   )


### PR DESCRIPTION
When building on Windows, uncrustify doesn't seem to use the
CMAKE_BUILD_TYPE variable and thus prints a warning about it.
Quiet that down with --no-warn-unused-cli.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the build warnings we are seeing in the nightly CI jobs, like https://ci.ros2.org/view/nightly/job/nightly_win_rel/2157/msbuild/