### PR TITLE
Fix system uncrustify version detection regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ macro(build_uncrustify)
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+      -DNoGitVersionString:BOOL=ON
       ${extra_cmake_args}
       -Wno-dev
       --no-warn-unused-cli
@@ -83,7 +84,7 @@ if(NOT res EQUAL 0)
   set(need_local_build TRUE)
 else()
   # Before 0.65 uncrustify used a different versioning scheme so the regex won't match
-  string(REGEX REPLACE "^Uncrustify-(.*)_f$" "\\1" version_prefix_match "${out}")
+  string(REGEX REPLACE "^Uncrustify(_d|)-(.*)_f$" "\\2" version_prefix_match "${out}")
   if(version_prefix_match STREQUAL "" OR version_prefix_match VERSION_LESS 0.72)
     set(need_local_build TRUE)
   endif()


### PR DESCRIPTION
Two changes here:
1. Make the regex handle the `_d` suffix, which may or may not be present in the system's binary.
2. Disable the automatic version suffix generation on the vendored package so that our own regex can parse it.

This may regress uncrustify tests on platforms which have newer versions of uncrustify with the `_d` suffix, where we were previously vendoring and will now see the system's version as adequate. We may need to set an upper bound on the acceptable version.

This will regress our beautiful green RHEL 9 builds :(

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18126)](http://ci.ros2.org/job/ci_linux/18126/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12660)](http://ci.ros2.org/job/ci_linux-aarch64/12660/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=336)](https://ci.ros2.org/job/ci_linux-rhel/336/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18775)](http://ci.ros2.org/job/ci_windows/18775/)