### PR TITLE
fix(cmake): Align Python3 find strategy with ament_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(uncrustify_vendor)
 
 find_package(ament_cmake REQUIRED)
@@ -35,6 +35,8 @@ ament_vendor(uncrustify_vendor
   PATCHES patches
   CMAKE_ARGS
     -DNoGitVersionString=ON
+    -DPython3_FIND_STRATEGY=LOCATION
+    -DPython3_FIND_UNVERSIONED_NAMES=FIRST
 )
 
 ament_package()


### PR DESCRIPTION
Standardize Python3 interpreter discovery to match ament_cmake_core's established strategy [1], ensuring consistent interpreter selection across the ROS 2 build system.

Changes:
- Set CMake variable Python3_FIND_STRATEGY to LOCATION
- Set CMake variable Python3_FIND_UNVERSIONED_NAMES to FIRST
- Bump up the minimum required CMake version to 3.20

This resolves potential inconsistencies where find_package(Python3) might select unintended Python interpreter to build uncrustify.

[1] [ament_cmake_core/cmake/core/python.cmake](https://github.com/ament/ament_cmake/blob/rolling/ament_cmake_core/cmake/core/python.cmake)